### PR TITLE
feat: add syscallproxy package

### DIFF
--- a/lambda/agents/agent.go
+++ b/lambda/agents/agent.go
@@ -9,9 +9,9 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path"
-	"syscall"
 
 	log "github.com/sirupsen/logrus"
+	"go.amzn.com/syscallproxy"
 )
 
 // AgentProcess is the common interface exposed by both internal and external agent processes
@@ -32,7 +32,7 @@ func NewExternalAgentProcess(path string, env []string, logWriter io.Writer) Ext
 	w := NewNewlineSplitWriter(logWriter)
 	command.Stdout = w
 	command.Stderr = w
-	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.SysProcAttr = syscallproxy.CreateNewProcessGroup()
 
 	return ExternalAgentProcess{
 		cmd: command,

--- a/lambda/metering/time.go
+++ b/lambda/metering/time.go
@@ -13,17 +13,20 @@ import (
 func Monotime() int64
 
 //go:linkname walltime runtime.walltime
-func walltime() (sec int64, nsec int32)
+//func walltime() (sec int64, nsec int32)
 
 // MonoToEpoch converts monotonic time nanos to epoch time nanos.
 func MonoToEpoch(t int64) int64 {
-	monoNsec := Monotime()
+	// `runtime.walltime` is not available on Windows. We need an alternative way
+	// of getting the wall clock, but for now we can live with less accuracy.
+	// monoNsec := Monotime()
 
-	wallSec, wallNsec32 := walltime()
-	wallNsec := wallSec*1e9 + int64(wallNsec32)
+	// wallSec, wallNsec32 := walltime()
+	// wallNsec := wallSec*1e9 + int64(wallNsec32)
 
-	clockOffset := wallNsec - monoNsec
-	return t + clockOffset
+	// clockOffset := wallNsec - monoNsec
+	// return t + clockOffset
+	return t
 }
 
 type ExtensionsResetDurationProfiler struct {

--- a/lambda/rapidcore/env/environment.go
+++ b/lambda/rapidcore/env/environment.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	log "github.com/sirupsen/logrus"
+	"go.amzn.com/syscallproxy"
 )
 
 const runtimeAPIAddressKey = "AWS_LAMBDA_RUNTIME_API"
@@ -201,7 +201,7 @@ func (e *Environment) getIntEnvVarOrDie(env map[string]string, name string) int 
 // It also makes CloseOnExec for this value.
 func (e *Environment) getSocketEnvVarOrDie(env map[string]string, name string) int {
 	sock := e.getIntEnvVarOrDie(env, name)
-	syscall.CloseOnExec(sock)
+	syscallproxy.CloseOnExec(sock)
 	return sock
 }
 
@@ -221,7 +221,7 @@ func (e *Environment) getOptionalSocketEnvVar(env map[string]string, name string
 		log.WithError(err).WithField("name", name).Fatal("Negative socket descriptor value")
 	}
 
-	syscall.CloseOnExec(sock)
+	syscallproxy.CloseOnExec(sock)
 	return sock
 }
 

--- a/lambda/runtimecmd/runtime_command.go
+++ b/lambda/runtimecmd/runtime_command.go
@@ -10,7 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"syscall"
+
+	"go.amzn.com/syscallproxy"
 )
 
 // CustomRuntimeCmd wraps exec.Cmd
@@ -28,7 +29,7 @@ func NewCustomRuntimeCmd(ctx context.Context, bootstrapCmd []string, dir string,
 
 	cmd.Env = env
 
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = syscallproxy.CreateNewProcessGroup()
 
 	if len(extraFiles) > 0 {
 		cmd.ExtraFiles = extraFiles

--- a/syscallproxy/syscallproxy.go
+++ b/syscallproxy/syscallproxy.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+package syscallproxy
+
+import (
+	"syscall"
+)
+
+func CloseOnExec(sock int) {
+	syscall.CloseOnExec(sock)
+}
+
+func CreateNewProcessGroup() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+func KillProcess(pid int) {
+	syscall.Kill(pid, syscall.SIGTERM)
+}
+
+func KillProcessOrProcessGroup(pid int) {
+	pgid, err := syscall.Getpgid(pid)
+	if err == nil {
+		syscall.Kill(-pgid, 9) // Negative pid sends signal to all in process group
+	} else {
+		syscall.Kill(pid, 9)
+	}
+}

--- a/syscallproxy/syscallproxy_windows.go
+++ b/syscallproxy/syscallproxy_windows.go
@@ -1,0 +1,30 @@
+package syscallproxy
+
+import (
+	"os"
+	"syscall"
+)
+
+func CloseOnExec(sock int) {
+	syscall.CloseOnExec(syscall.Handle(sock))
+}
+
+func CreateNewProcessGroup() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+func KillProcess(pid int) {
+	p, err := os.FindProcess(pid)
+
+	if err != nil {
+		return
+	}
+
+	p.Signal(syscall.SIGTERM)
+}
+
+func KillProcessOrProcessGroup(pid int) {
+	KillProcess(pid)
+}


### PR DESCRIPTION
Adds a package that acts as a cross-OS proxy for all `syscall` methods. This package uses build constraints to provide an implementation for Windows and another for the remaining archs.